### PR TITLE
[NS-660] fix: remove headless switch to allow billing service to call ksqldb

### DIFF
--- a/charts/cp-ksql-server/templates/deployment.yaml
+++ b/charts/cp-ksql-server/templates/deployment.yaml
@@ -76,10 +76,8 @@ spec:
           - name: kafka-user-secret
             mountPath: /etc/tls/kafka-user
             readOnly: true
-          {{- if .Values.ksql.headless }}
           - name: ksql-queries
             mountPath: /etc/ksql/queries
-          {{- end }}
           env:
           - name: KSQL_BOOTSTRAP_SERVERS
             value: {{ template "cp-ksql-server.kafka.bootstrapServers" . }}
@@ -89,13 +87,10 @@ spec:
             value: {{ template "cp-ksql-server.cp-schema-registry.service-name" . }}
           - name: KSQL_HEAP_OPTS
             value: "{{ .Values.heapOptions }}"
-          {{- if .Values.ksql.headless }}
           - name: KSQL_KSQL_QUERIES_FILE
             value: /etc/ksql/queries/queries.sql
-          {{- else }}
           - name: KSQL_LISTENERS
             value: http://0.0.0.0:8088
-          {{- end }}
           {{- range $key, $value := .Values.configurationOverrides }}
             {{- if (kindIs "map" $value) }}
               {{- if hasKey $value "secret" }}
@@ -125,11 +120,9 @@ spec:
         configMap:
           name: {{ template "cp-ksql-server.fullname" . }}-jmx-configmap
       {{- end }}
-      {{- if .Values.ksql.headless }}
       - name: ksql-queries
         configMap:
           name: {{ template "cp-ksql-server.fullname" . }}-ksql-queries-configmap
-      {{- end }}
       # TODO: Optional if .Values.configurationOverrides.security.protocol is set to SSL, generic
       - name: kafka-cluster-ca-cert-secret
         secret:

--- a/charts/cp-ksql-server/values.yaml
+++ b/charts/cp-ksql-server/values.yaml
@@ -83,7 +83,6 @@ external:
 ## Headless mode
 ## ref: https://docs.confluent.io/current/ksql/docs/installation/server-config/index.html
 ksql:
-  headless: true
   # -- A string containing a set of ksql statements to run on startup.
   queriesSql: ""
 


### PR DESCRIPTION
the go lib communicates with ksql over the rest api, which requires the KSQL_LISTENERS to be set to localhost:8088.

when we set `headless: true`, it disables the listener. I guess the java client communicates more directly