### PR TITLE
[NS-660] fix: revert #2 #3 #4

### DIFF
--- a/charts/cp-ksql-server/README.md
+++ b/charts/cp-ksql-server/README.md
@@ -4,6 +4,7 @@ This chart bootstraps a deployment of a Confluent KSQL Server.
 
 This is an example deployment which runs KSQL Server in non-interactive
 mode.
+The included queries file `queries.sql` is a stub provided to illustrate one possible approach to mounting queries in the server container via ConfigMap.
 
 ## Prerequisites
 

--- a/charts/cp-ksql-server/queries.sql
+++ b/charts/cp-ksql-server/queries.sql
@@ -1,0 +1,19 @@
+-- From http://docs.confluent.io/current/ksql/docs/tutorials/basics-docker.html#create-a-stream-and-table
+
+-- Create a stream pageviews_original from the Kafka topic pageviews, specifying the value_format of DELIMITED
+CREATE STREAM pageviews_original (viewtime bigint, userid varchar, pageid varchar) WITH (kafka_topic='pageviews', value_format='DELIMITED');
+
+-- Create a table users_original from the Kafka topic users, specifying the value_format of JSON
+CREATE TABLE users_original (registertime BIGINT, gender VARCHAR, regionid VARCHAR, userid VARCHAR) WITH (kafka_topic='users', value_format='JSON', key = 'userid');
+
+-- Create a persistent query by using the CREATE STREAM keywords to precede the SELECT statement
+CREATE STREAM pageviews_enriched AS SELECT users_original.userid AS userid, pageid, regionid, gender FROM pageviews_original LEFT JOIN users_original ON pageviews_original.userid = users_original.userid;
+
+-- Create a new persistent query where a condition limits the streams content, using WHERE
+CREATE STREAM pageviews_female AS SELECT * FROM pageviews_enriched WHERE gender = 'FEMALE';
+
+-- Create a new persistent query where another condition is met, using LIKE
+CREATE STREAM pageviews_female_like_89 WITH (kafka_topic='pageviews_enriched_r8_r9') AS SELECT * FROM pageviews_female WHERE regionid LIKE '%_8' OR regionid LIKE '%_9';
+
+-- Create a new persistent query that counts the pageviews for each region and gender combination in a tumbling window of 30 seconds when the count is greater than one
+CREATE TABLE pageviews_regions WITH (VALUE_FORMAT='avro') AS SELECT gender, regionid , COUNT(*) AS numusers FROM pageviews_enriched WINDOW TUMBLING (size 30 second) GROUP BY gender, regionid HAVING COUNT(*) > 1;

--- a/charts/cp-ksql-server/templates/deployment.yaml
+++ b/charts/cp-ksql-server/templates/deployment.yaml
@@ -76,8 +76,10 @@ spec:
           - name: kafka-user-secret
             mountPath: /etc/tls/kafka-user
             readOnly: true
+          {{- if .Values.ksql.headless }}
           - name: ksql-queries
             mountPath: /etc/ksql/queries
+          {{- end }}
           env:
           - name: KSQL_BOOTSTRAP_SERVERS
             value: {{ template "cp-ksql-server.kafka.bootstrapServers" . }}
@@ -87,10 +89,13 @@ spec:
             value: {{ template "cp-ksql-server.cp-schema-registry.service-name" . }}
           - name: KSQL_HEAP_OPTS
             value: "{{ .Values.heapOptions }}"
+          {{- if .Values.ksql.headless }}
           - name: KSQL_KSQL_QUERIES_FILE
             value: /etc/ksql/queries/queries.sql
+          {{- else }}
           - name: KSQL_LISTENERS
             value: http://0.0.0.0:8088
+          {{- end }}
           {{- range $key, $value := .Values.configurationOverrides }}
             {{- if (kindIs "map" $value) }}
               {{- if hasKey $value "secret" }}
@@ -120,9 +125,11 @@ spec:
         configMap:
           name: {{ template "cp-ksql-server.fullname" . }}-jmx-configmap
       {{- end }}
+      {{- if .Values.ksql.headless }}
       - name: ksql-queries
         configMap:
           name: {{ template "cp-ksql-server.fullname" . }}-ksql-queries-configmap
+      {{- end }}
       # TODO: Optional if .Values.configurationOverrides.security.protocol is set to SSL, generic
       - name: kafka-cluster-ca-cert-secret
         secret:

--- a/charts/cp-ksql-server/templates/ksql-queries-configmap.yaml
+++ b/charts/cp-ksql-server/templates/ksql-queries-configmap.yaml
@@ -8,5 +8,8 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  queries.sql: |-
-    {{ .Values.queriesSql | nindent 4 }}
+  {{- $files := .Files }}
+  {{- range tuple "queries.sql" }}
+  {{ . }}: |-
+{{ $files.Get . | indent 4 }}
+  {{- end }}

--- a/charts/cp-ksql-server/templates/ksql-queries-configmap.yaml
+++ b/charts/cp-ksql-server/templates/ksql-queries-configmap.yaml
@@ -9,4 +9,4 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   queries.sql: |-
-    {{ .Values.ksql.queriesSql | nindent 4 }}
+    {{ .Values.queriesSql | nindent 4 }}

--- a/charts/cp-ksql-server/values.yaml
+++ b/charts/cp-ksql-server/values.yaml
@@ -84,8 +84,6 @@ external:
 ## ref: https://docs.confluent.io/current/ksql/docs/installation/server-config/index.html
 ksql:
   headless: true
-  # -- A string containing a set of ksql statements to run on startup.
-  queriesSql: ""
 
 ## You can list load balanced service endpoint, or list of all brokers (which is hard in K8s).  e.g.:
 ## bootstrapServers: "PLAINTEXT://dozing-prawn-kafka-headless:9092"

--- a/charts/cp-ksql-server/values.yaml
+++ b/charts/cp-ksql-server/values.yaml
@@ -83,6 +83,7 @@ external:
 ## Headless mode
 ## ref: https://docs.confluent.io/current/ksql/docs/installation/server-config/index.html
 ksql:
+  headless: true
   # -- A string containing a set of ksql statements to run on startup.
   queriesSql: ""
 


### PR DESCRIPTION
We can't use a queries file as it implicitly enables headless mode.

Headless mode needs to be disabled in order to interact with ksqldb over its REST API